### PR TITLE
[FIX] RCE through execFile

### DIFF
--- a/lib/jscover.js
+++ b/lib/jscover.js
@@ -11,7 +11,7 @@
  */
 
 var debug = require('debug')('jscover');
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var path = require('path');
 var ndir = require('ndir');
 var fse = require('fs-extra');
@@ -55,8 +55,10 @@ module.exports = function jscover(source, target, options, callback) {
   cmd += ' --exclude=node_modules --exclude=.git/ --exclude=.svn/';
   cmd += ' --exclude="' + tmpTarget + '" --exclude="' + target + '"';
   cmd += ' "' + source + '" "' + tmpTarget + '"';
+
+  cmd = cmd.split(' ');
   debug(cmd);
-  var child = exec(cmd, function (err, stdout, stderr) {
+  var child = execFile(cmd[0], cmd.slice(1), function (err, stdout, stderr) {
     var output = '';
     if (stdout) {
       output += stdout;


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://www.huntr.dev/app/bounties/open/1-npm-jscover

### ⚙️ Description *

I used the `execFile` function instead of `exec` in order to avoid `arbitrary command execution`.

### 💻 Technical Description *

The `execFile` function makes possible avoid further checks on the `filename` passed (`source` and `target`) which could lead to other issues using redundant `regexes` or resolving the filename it-self. Applying it, it's possible avoid `arbitrary command execution` as every part which takes inputs controlled by the `attacker` is considered an `argument` and so it's impossible inject commands the library shouldn't execute.

### 🐛 Proof of Concept (PoC) *

1. Download the library in local
2. Make the following `poc.js` file:

```js
var jscover = require('./jscover');
jscover('sssss', '"; touch HACKED; #', '', function(){})
```
3. Run the PoC: `node poc.js`
4. A file named `HACKED` will be created
![Screenshot from 2020-07-21 13-12-15](https://user-images.githubusercontent.com/33063403/88049400-5f50a200-cb55-11ea-942d-d614a1067fb2.png)

### 🔥 Proof of Fix (PoF) *

Same steps of above with fixed version
![Screenshot from 2020-07-21 13-15-40](https://user-images.githubusercontent.com/33063403/88049420-6a0b3700-cb55-11ea-92e7-c61941b4c612.png)

### 👍 User Acceptance Testing (UAT)

All works correctly